### PR TITLE
Tweaked RingBuffer to be generic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
-# Makefile for ringbuffer
-#
-CPP = g++ --std=c++11
-CFLAGS = -Wall
-LDFLAGS= -lpthread -ljack
+# Makefile for RingBuffer
 
+
+ifeq ($(OS),Linux)
+	LDFLAGS= -lpthread -ljack
+	CPP = g++ --std=c++17
+else
+	CPP = clang++ --std=c++17
+endif
+
+CFLAGS = -Wall
 
 OBJ = ringbuffer.o ringbuffer_main.o
 
@@ -20,4 +25,3 @@ ringbuffer: $(OBJ)
 clean:
 	rm -f *.o
 	rm -f `find . -perm /111 -type f`
-

--- a/ringbuffer.h
+++ b/ringbuffer.h
@@ -1,32 +1,44 @@
-/*
- * ringbuffer.h
- */
+
+//ringbuffer.h
 
 #include <atomic>
 #include <string>
 
+
+template<typename FloatType>
 class RingBuffer
 {
 public:
-  RingBuffer(unsigned long size,std::string name);
-  ~RingBuffer();
-  unsigned long push(float *data,unsigned long n);
-  unsigned long pop(float *data,unsigned long n);
-  unsigned long items_available_for_write();
-  unsigned long items_available_for_read();
-  bool isLockFree();
-  void pushMayBlock(bool block);
-  void popMayBlock(bool block);
-  void setBlockingNap(unsigned long blockingNap);
-private:
-  unsigned long size;
-  float *buffer;
-  std::atomic<unsigned long> tail; // write pointer
-  std::atomic<unsigned long> head; // read pointer
-  unsigned long itemsize; // also depends on #channels
-  std::string name;
-  bool blockingPush;
-  bool blockingPop;
-  unsigned long blockingNap=500;
-}; // RingBuffer{}
 
+    using uint64 = unsigned long;
+
+    RingBuffer(uint64 size, const std::string& name);
+    ~RingBuffer();
+
+    auto push(FloatType* data, uint64 numSamples) -> uint64;
+    auto pop(FloatType* data, uint64 numSamples) -> uint64;
+    auto numItemsAvailableForWrite() const -> uint64;
+    auto numItemsAvailableForRead() const -> uint64;
+
+    auto isLockFree() const -> bool;
+    auto pushMayBlock(bool block) -> void;
+    auto popMayBlock(bool block) -> void;
+    auto setBlockingNap(uint64 blockingNap) -> void;
+
+private:
+
+    uint64 size;
+    FloatType* buffer;
+
+    std::atomic<uint64> tail; // write index
+    std::atomic<uint64> head; // read index
+
+    static constexpr uint64 itemSize { sizeof(FloatType) };
+
+    const std::string name;
+
+    bool blockingPush;
+    bool blockingPop;
+
+    uint64 blockingNap { 500 };
+};

--- a/ringbuffer_main.cpp
+++ b/ringbuffer_main.cpp
@@ -1,58 +1,80 @@
 #include <iostream>
 #include "ringbuffer.h"
 
+//this makes the whole thing need C++17, but the RingBuffer class
+//on its own should also be able to work with C++14
+template<typename...Args>
+auto print(Args... args){
+    ([](auto&& arg){ std::cout << arg << ' '; }(args), ...);
+    std::cout << '\n';
+}
 
 int main()
 {
-RingBuffer buffer(10,"Buffer");
-float inputdata[8]={1,2,3,4,5,6,7,8};
-float anadata[8];
+    //could also be RingBuffer<double> or RingBuffer<long double> for more precision,
+    //To test this, change the using FloatType to double or long double
+    using FloatType = float;
 
-  if(buffer.isLockFree()) std::cout << "Lock free\n";
-  else std::cout << "Not lock free\n";
+    RingBuffer<FloatType> buffer { 10, "Buffer" };
 
-  std::cout << "Avail for write: " << buffer.items_available_for_write() << std::endl;
-  std::cout << "Avail for read: " << buffer.items_available_for_read() << std::endl;
-  buffer.push(inputdata,1);
-  buffer.push(inputdata,5);
-    buffer.pop(anadata,5);
-  std::cout << "Avail for write: " << buffer.items_available_for_write() << std::endl;
-  std::cout << "Avail for read: " << buffer.items_available_for_read() << std::endl;
+    FloatType inputdata[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+    FloatType anadata[8];
 
-  buffer.push(inputdata,5);
-  std::cout << "Avail for write: " << buffer.items_available_for_write() << std::endl;
-  std::cout << "Avail for read: " << buffer.items_available_for_read() << std::endl;
-  buffer.push(inputdata,1);
-  std::cout << "Avail for write: " << buffer.items_available_for_write() << std::endl;
-  std::cout << "Avail for read: " << buffer.items_available_for_read() << std::endl;
-  buffer.push(inputdata,1);
-  std::cout << "Avail for write: " << buffer.items_available_for_write() << std::endl;
-  std::cout << "Avail for read: " << buffer.items_available_for_read() << std::endl;
+    buffer.isLockFree() ? print("Lock free") : print("Not lock free");
 
-  if(buffer.items_available_for_read() >= 5){
-    buffer.pop(anadata,5);
-  std::cout << "Avail for write: " << buffer.items_available_for_write() << std::endl;
-  std::cout << "Avail for read: " << buffer.items_available_for_read() << std::endl;
-    for(unsigned long i=0; i<5; i++) std::cout << anadata[i] << " ";
-  }
-  else std::cout << "Not enough data" << std::endl;
+    print("Available for write:",   buffer.numItemsAvailableForWrite());
+    print("Available for read:",    buffer.numItemsAvailableForRead());
 
-  buffer.push(inputdata,1);
-  std::cout << "Avail for write: " << buffer.items_available_for_write() << std::endl;
-  std::cout << "Avail for read: " << buffer.items_available_for_read() << std::endl;
-  buffer.push(inputdata,1);
-  std::cout << "Avail for write: " << buffer.items_available_for_write() << std::endl;
-  std::cout << "Avail for read: " << buffer.items_available_for_read() << std::endl;
+    buffer.push(inputdata, 1);
+    buffer.push(inputdata, 5);
+    buffer.pop(anadata, 5);
 
-  if(buffer.items_available_for_read() >= 5){
-    buffer.pop(anadata,5);
-  std::cout << "Avail for write: " << buffer.items_available_for_write() << std::endl;
-  std::cout << "Avail for read: " << buffer.items_available_for_read() << std::endl;
-    for(unsigned long i=0; i<5; i++) std::cout << anadata[i] << " ";
-  }
-  else std::cout << "Not enough data" << std::endl;
+    print("Available for write:",   buffer.numItemsAvailableForWrite());
+    print("Available for read:",    buffer.numItemsAvailableForRead());
 
-  std::cout << std::endl;
-  return 0;
+    buffer.push(inputdata, 5);
+
+    print("Available for write:",   buffer.numItemsAvailableForWrite());
+    print("Available for read:",    buffer.numItemsAvailableForRead());
+
+    buffer.push(inputdata, 1);
+
+    print("Available for write:",   buffer.numItemsAvailableForWrite());
+    print("Available for read:",    buffer.numItemsAvailableForRead());
+
+    buffer.push(inputdata, 1);
+
+    print("Available for write:",   buffer.numItemsAvailableForWrite());
+    print("Available for read:",    buffer.numItemsAvailableForRead());
+
+    if(buffer.numItemsAvailableForRead() >= 5)
+    {
+        buffer.pop(anadata, 5);
+        print("Available for write:",   buffer.numItemsAvailableForWrite());
+        print("Available for read:",    buffer.numItemsAvailableForRead());
+        for(int i = 0; i < 5; ++i) print("Anadata: i =", i, ":", anadata[i]);
+    }
+    else print("Not enough data");
+
+    buffer.push(inputdata, 1);
+
+    print("Available for write:",   buffer.numItemsAvailableForWrite());
+    print("Available for read:",    buffer.numItemsAvailableForRead());
+
+    buffer.push(inputdata, 1);
+
+    print("Available for write:",   buffer.numItemsAvailableForWrite());
+    print("Available for read:",    buffer.numItemsAvailableForRead());
+
+    if(buffer.numItemsAvailableForRead() >= 5)
+    {
+        buffer.pop(anadata, 5);
+        print("Available for write:",   buffer.numItemsAvailableForWrite());
+        print("Available for read:",    buffer.numItemsAvailableForRead());
+        for(int i = 0; i < 5; ++i) print("Anadata: i =", i, ":", anadata[i]);
+    }
+    else print("Not enough data\n");
+
+
+    return 0;
 }
-

--- a/ringbuffer_main.cpp
+++ b/ringbuffer_main.cpp
@@ -9,7 +9,7 @@ auto print(Args... args){
     std::cout << '\n';
 }
 
-int main()
+auto main() -> int
 {
     //could also be RingBuffer<double> or RingBuffer<long double> for more precision,
     //To test this, change the using FloatType to double or long double


### PR DESCRIPTION
Made RingBuffer generic for float, double and long double as those are the most common types used in audio programming.

Needs C++14 now to compile, due to trailing return types. C++17 is needed for ringbuffer_main, because of the print function. 

Makefile is also adjusted, now added macOS support with Clang as the compiler.